### PR TITLE
fix: generated yaml

### DIFF
--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -16,15 +16,15 @@ Object {
       "value1": Any<String>,
       "value2": Any<String>,
     },
-  },
-  "template": Object {
-    "metadata": Object {
-      "annotations": Object {
-        "sealedsecrets.bitnami.com/cluster-wide": "true",
+    "template": Object {
+      "metadata": Object {
+        "annotations": Object {
+          "sealedsecrets.bitnami.com/cluster-wide": "true",
+        },
+        "name": "some-name",
       },
-      "name": "some-name",
+      "type": "Opaque",
     },
-    "type": "Opaque",
   },
 }
 `;
@@ -45,15 +45,15 @@ Object {
       "value1": Any<String>,
       "value2": Any<String>,
     },
-  },
-  "template": Object {
-    "metadata": Object {
-      "annotations": Object {
-        "sealedsecrets.bitnami.com/namespace-wide": "true",
+    "template": Object {
+      "metadata": Object {
+        "annotations": Object {
+          "sealedsecrets.bitnami.com/namespace-wide": "true",
+        },
+        "name": "some-name",
       },
-      "name": "some-name",
+      "type": "Opaque",
     },
-    "type": "Opaque",
   },
 }
 `;
@@ -72,13 +72,13 @@ Object {
       "value1": Any<String>,
       "value2": Any<String>,
     },
-  },
-  "template": Object {
-    "metadata": Object {
-      "annotations": Object {},
-      "name": "some-name",
+    "template": Object {
+      "metadata": Object {
+        "annotations": Object {},
+        "name": "some-name",
+      },
+      "type": "Opaque",
     },
-    "type": "Opaque",
   },
 }
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -269,13 +269,13 @@ export const getSealedSecret = async (args: GetSealedSecretParams) => {
     },
     spec: {
       encryptedData,
-    },
-    template: {
-      metadata: {
-        annotations,
-        name: args.name,
+      template: {
+        metadata: {
+          annotations,
+          name: args.name,
+        },
+        type: 'Opaque',
       },
-      type: 'Opaque',
     },
   };
 


### PR DESCRIPTION
The generated YAML wasnt kube-valid, the `template` should reside in the `spec` key